### PR TITLE
fix CLI auth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Create a file named opereto.yaml in your home directory containing Opereto acces
 ~/opereto.yaml
 ```
 opereto_host: https://your_opereto_service_url
-opereto_user: your_opereto_username
-opereto_password: your_opereto_password
+opereto_auth: your_opereto_authentication_token
 ```
 
 From the command line console, please type:


### PR DESCRIPTION
version 1.0.106 (as seen in [pypi](https://pypi.org/project/pyopereto/1.0.106/)) no longer supports cli connection with user and password - it now uses token instead.